### PR TITLE
feat: add system control actions to ASV_SDR protocol

### DIFF
--- a/src/Asv.Mavlink.Test/Microservices/AsvSdr/AsvSdrExTests.cs
+++ b/src/Asv.Mavlink.Test/Microservices/AsvSdr/AsvSdrExTests.cs
@@ -666,4 +666,60 @@ public class AsvSdrExTests
             }
         });
     }
+
+    [Fact]
+    public async Task Check_System_Control_Action_Reboot_Behaviour()
+    {
+        var (asvSdrClientEx, asvSdrServerEx) = await SetUpConnection();
+
+        asvSdrServerEx.SystemControlAction = (action, cancel) =>
+        {
+            return action switch
+            {
+                AsvSdrSystemControlAction.AsvSdrSystemControlActionReboot => Task.FromResult(
+                    MavResult.MavResultAccepted),
+                AsvSdrSystemControlAction.AsvSdrSystemControlActionShutdown => Task.FromResult(
+                    MavResult.MavResultFailed),
+                _ => Task.FromResult(MavResult.MavResultUnsupported)
+            };
+        };
+
+        var mavRebootResult =
+            await asvSdrClientEx.SystemControlAction(AsvSdrSystemControlAction.AsvSdrSystemControlActionReboot,
+                CancellationToken.None);
+        
+        var mavShutdownResult = await asvSdrClientEx.SystemControlAction(AsvSdrSystemControlAction.AsvSdrSystemControlActionShutdown,
+            CancellationToken.None);
+        
+        Assert.True(mavRebootResult == MavResult.MavResultAccepted);
+        Assert.True(mavShutdownResult == MavResult.MavResultFailed);
+    }
+    
+    [Fact]
+    public async Task Check_System_Control_Action_Shutdown_Behaviour()
+    {
+        var (asvSdrClientEx, asvSdrServerEx) = await SetUpConnection();
+
+        asvSdrServerEx.SystemControlAction = (action, cancel) =>
+        {
+            return action switch
+            {
+                AsvSdrSystemControlAction.AsvSdrSystemControlActionReboot => Task.FromResult(
+                    MavResult.MavResultFailed),
+                AsvSdrSystemControlAction.AsvSdrSystemControlActionShutdown => Task.FromResult(
+                    MavResult.MavResultAccepted),
+                _ => Task.FromResult(MavResult.MavResultUnsupported)
+            };
+        };
+
+        var mavRebootResult =
+            await asvSdrClientEx.SystemControlAction(AsvSdrSystemControlAction.AsvSdrSystemControlActionReboot,
+                CancellationToken.None);
+        
+        var mavShutdownResult = await asvSdrClientEx.SystemControlAction(AsvSdrSystemControlAction.AsvSdrSystemControlActionShutdown,
+            CancellationToken.None);
+        
+        Assert.True(mavRebootResult == MavResult.MavResultFailed);
+        Assert.True(mavShutdownResult == MavResult.MavResultAccepted);
+    }
 }

--- a/src/Asv.Mavlink/Microservices/AsvSdr/Client/Ex/AsvSdrClientEx.cs
+++ b/src/Asv.Mavlink/Microservices/AsvSdr/Client/Ex/AsvSdrClientEx.cs
@@ -193,4 +193,18 @@ public class AsvSdrClientEx : DisposableOnceWithCancel, IAsvSdrClientEx
         return result.Result;
     }
 
+    public async Task<MavResult> SystemControlAction(AsvSdrSystemControlAction action, CancellationToken cancel)
+    {
+        using var cs = CancellationTokenSource.CreateLinkedTokenSource(DisposeCancel, cancel);
+        var result = await _commandClient.CommandLong((V2.Common.MavCmd)MavCmd.MavCmdAsvSdrSystemControlAction,
+            BitConverter.ToSingle(BitConverter.GetBytes((uint)action)),
+            Single.NaN,
+            Single.NaN,
+            Single.NaN,
+            Single.NaN,
+            Single.NaN,
+            Single.NaN,
+            cs.Token).ConfigureAwait(false);
+        return result.Result;
+    }
 }

--- a/src/Asv.Mavlink/Microservices/AsvSdr/Client/Ex/IAsvSdrClientEx.cs
+++ b/src/Asv.Mavlink/Microservices/AsvSdr/Client/Ex/IAsvSdrClientEx.cs
@@ -23,6 +23,7 @@ public interface IAsvSdrClientEx
     Task<MavResult> StartRecord(string recordName, CancellationToken cancel);
     Task<MavResult> StopRecord(CancellationToken cancel);
     Task<MavResult> CurrentRecordSetTag(string tagName, AsvSdrRecordTagType type, byte[] rawValue , CancellationToken cancel);
+    Task<MavResult> SystemControlAction(AsvSdrSystemControlAction action, CancellationToken cancel);
 }
 
 public static class AsvSdrClientExHelper

--- a/src/Asv.Mavlink/Microservices/AsvSdr/Server/Ex/AsvSdrServerEx.cs
+++ b/src/Asv.Mavlink/Microservices/AsvSdr/Server/Ex/AsvSdrServerEx.cs
@@ -91,12 +91,21 @@ public class AsvSdrServerEx : DisposableOnceWithCancel, IAsvSdrServerEx
             var result = await CurrentRecordSetTag((AsvSdrRecordTagType)tagType,name,valueArray, cs.Token).ConfigureAwait(false);
             return new CommandResult(result);
         };
+        commands[(MavCmd)V2.AsvSdr.MavCmd.MavCmdAsvSdrSystemControlAction] = async (id, args, cancel) =>
+        {
+            if (SystemControlAction == null) return new CommandResult(MavResult.MavResultUnsupported);
+            using var cs = CancellationTokenSource.CreateLinkedTokenSource(DisposeCancel, cancel);
+            var action = (AsvSdrSystemControlAction)BitConverter.ToUInt32(BitConverter.GetBytes(args.Payload.Param1));
+            var result = await SystemControlAction(action, cs.Token).ConfigureAwait(false);
+            return new CommandResult(result);
+        };
     }
 
     public SetModeDelegate SetMode { get; set; }
     public StartRecordDelegate StartRecord { get; set; }
     public StopRecordDelegate StopRecord { get; set; }
     public CurrentRecordSetTagDelegate CurrentRecordSetTag { get; set; }
+    public SystemControlActionDelegate SystemControlAction { get; set; }
     public IAsvSdrServer Base { get; }
     public IRxEditableValue<AsvSdrCustomMode> CustomMode { get; }
 }

--- a/src/Asv.Mavlink/Microservices/AsvSdr/Server/Ex/IAsvSdrServerEx.cs
+++ b/src/Asv.Mavlink/Microservices/AsvSdr/Server/Ex/IAsvSdrServerEx.cs
@@ -15,6 +15,8 @@ public delegate Task<MavResult> StopRecordDelegate(CancellationToken cancel);
 
 public delegate Task<MavResult> CurrentRecordSetTagDelegate(AsvSdrRecordTagType type, string name, byte[] value, CancellationToken cancel);
 
+public delegate Task<MavResult> SystemControlActionDelegate(AsvSdrSystemControlAction action, CancellationToken cancel);
+
 public interface IAsvSdrServerEx
 {
     IAsvSdrServer Base { get; }
@@ -23,5 +25,5 @@ public interface IAsvSdrServerEx
     StartRecordDelegate StartRecord { set; }
     StopRecordDelegate StopRecord { set; }
     CurrentRecordSetTagDelegate CurrentRecordSetTag { set; }
-    
+    SystemControlActionDelegate SystemControlAction { set; }
 }

--- a/src/Asv.Mavlink/Microservices/AsvSdr/Server/IAsvSdrServer.cs
+++ b/src/Asv.Mavlink/Microservices/AsvSdr/Server/IAsvSdrServer.cs
@@ -23,7 +23,6 @@ namespace Asv.Mavlink
         Task SendRecordDataResponse(Action<AsvSdrRecordDataResponsePayload> setValueCallback, CancellationToken cancel = default);
         Task SendRecordData(AsvSdrCustomMode mode, Action<IPayload> setValueCallback, CancellationToken cancel = default);
         IPacketV2<IPayload> CreateRecordData(AsvSdrCustomMode mode);
-        
     }
 
     public static class AsvSdrServerHelper
@@ -146,8 +145,5 @@ namespace Asv.Mavlink
                 x.Result = AsvSdrRequestAck.AsvSdrRequestAckOk;
             }, CancellationToken.None);
         }
-        
-          
-        
     }
 }

--- a/src/Asv.Mavlink/Protocol/Dialects/asv_sdr.xml
+++ b/src/Asv.Mavlink/Protocol/Dialects/asv_sdr.xml
@@ -60,6 +60,16 @@
         <param index="6">Tag value data 0-3 bytes depends on the type of tag.</param>
         <param index="7">Tag value data 4-7 bytes depends on the type of tag.</param>
       </entry>
+      <entry value="13104" name="MAV_CMD_ASV_SDR_SYSTEM_CONTROL_ACTION">
+        <description>Send shutdown or reboot command.</description>
+        <param index="1">ASV_SDR_SYSTEM_CONTROL_ACTION (uint32).</param>
+        <param index="2">Empty.</param>
+        <param index="3">Empty.</param>
+        <param index="4">Empty.</param>
+        <param index="5">Empty.</param>
+        <param index="6">Empty.</param>
+        <param index="7">Empty.</param>
+      </entry>
     </enum>
     
     <enum name="ASV_SDR_RECORD_TAG_TYPE">
@@ -119,6 +129,16 @@
       </entry>
       <entry name="ASV_SDR_REQUEST_ACK_FAIL">
         <description>Command error.[!WRAP_TO_V2_EXTENSION_PACKET!]</description>
+      </entry>
+    </enum>
+    
+    <enum name="ASV_SDR_SYSTEM_CONTROL_ACTION">
+      <description>SDR system control actions [!WRAP_TO_V2_EXTENSION_PACKET!]</description>
+      <entry name="ASV_SDR_SYSTEM_CONTROL_ACTION_REBOOT">
+        <description>Request system reboot [!WRAP_TO_V2_EXTENSION_PACKET!]</description>
+      </entry>
+      <entry name="ASV_SDR_SYSTEM_CONTROL_ACTION_SHUTDOWN">
+        <description>Request system shutdown [!WRAP_TO_V2_EXTENSION_PACKET!]</description>
       </entry>
     </enum>
   </enums>

--- a/src/Asv.Mavlink/Protocol/Messages/asv_sdr.cs
+++ b/src/Asv.Mavlink/Protocol/Messages/asv_sdr.cs
@@ -120,6 +120,18 @@ namespace Asv.Mavlink.V2.AsvSdr
         /// MAV_CMD_ASV_SDR_SET_RECORD_TAG
         /// </summary>
         MavCmdAsvSdrSetRecordTag = 13103,
+        /// <summary>
+        /// Send shutdown or reboot command.
+        /// Param 1 - ASV_SDR_SYSTEM_CONTROL_ACTION (uint32).
+        /// Param 2 - Empty.
+        /// Param 3 - Empty.
+        /// Param 4 - Empty.
+        /// Param 5 - Empty.
+        /// Param 6 - Empty.
+        /// Param 7 - Empty.
+        /// MAV_CMD_ASV_SDR_SYSTEM_CONTROL_ACTION
+        /// </summary>
+        MavCmdAsvSdrSystemControlAction = 13104,
     }
 
     /// <summary>
@@ -219,6 +231,24 @@ namespace Asv.Mavlink.V2.AsvSdr
         /// ASV_SDR_REQUEST_ACK_FAIL
         /// </summary>
         AsvSdrRequestAckFail = 2,
+    }
+
+    /// <summary>
+    /// SDR system control actions [!WRAP_TO_V2_EXTENSION_PACKET!]
+    ///  ASV_SDR_SYSTEM_CONTROL_ACTION
+    /// </summary>
+    public enum AsvSdrSystemControlAction:uint
+    {
+        /// <summary>
+        /// Request system reboot [!WRAP_TO_V2_EXTENSION_PACKET!]
+        /// ASV_SDR_SYSTEM_CONTROL_ACTION_REBOOT
+        /// </summary>
+        AsvSdrSystemControlActionReboot = 0,
+        /// <summary>
+        /// Request system shutdown [!WRAP_TO_V2_EXTENSION_PACKET!]
+        /// ASV_SDR_SYSTEM_CONTROL_ACTION_SHUTDOWN
+        /// </summary>
+        AsvSdrSystemControlActionShutdown = 1,
     }
 
 


### PR DESCRIPTION
Added system control actions including shutdown and reboot commands to the ASV_SDR protocol. This provides a protocol-level instruction to perform these actions, improving overall system controllability. Updated the corresponding client and server functionalities, as well as relevant documentation in the XML.

Two new test cases have been added to validate the actions of system control - 'Reboot' and 'Shutdown'. These tests ensure that the system returns the expected outcomes for these specific actions. The purpose is to enhance the robustness of our test suite and ascertain the behavior of important system control actions.

Asana: 
https://app.asana.com/0/1203851531040615/1204985023342565/f

https://app.asana.com/0/1203851531040615/1204985023342567/f