### PR TITLE
fix: add server handlers in AsvSdrExTests

### DIFF
--- a/src/Asv.Mavlink.Test/Microservices/AsvSdr/AsvSdrExTests.cs
+++ b/src/Asv.Mavlink.Test/Microservices/AsvSdr/AsvSdrExTests.cs
@@ -529,8 +529,17 @@ public class AsvSdrExTests
     {
         var (asvSdrClientEx, asvSdrServerEx) = await SetUpConnection();
 
+        asvSdrServerEx.StartRecord = (name, cancel) =>
+        {
+            return name switch
+            {
+                "TestRecord" => Task.FromResult(MavResult.MavResultAccepted),
+                _ => Task.FromResult<MavResult>(MavResult.MavResultFailed)
+            };
+        };
+
         var mavResult = await asvSdrClientEx.StartRecord("TestRecord", CancellationToken.None);
-        Assert.True(mavResult == MavResult.MavResultUnsupported);
+        Assert.True(mavResult == MavResult.MavResultAccepted);
     }
     
     [Fact]
@@ -538,8 +547,10 @@ public class AsvSdrExTests
     {
         var (asvSdrClientEx, asvSdrServerEx) = await SetUpConnection();
 
+        asvSdrServerEx.StopRecord = cancel => Task.FromResult(MavResult.MavResultAccepted);
+
         var mavResult = await asvSdrClientEx.StopRecord(CancellationToken.None);
-        Assert.True(mavResult == MavResult.MavResultUnsupported);
+        Assert.True(mavResult == MavResult.MavResultAccepted);
     }
     
     [Fact]
@@ -547,9 +558,15 @@ public class AsvSdrExTests
     {
         var (asvSdrClientEx, asvSdrServerEx) = await SetUpConnection();
 
+        asvSdrServerEx.CurrentRecordSetTag = (type, name, value, cancel) =>
+        {
+            SdrWellKnown.CheckTagName(name);
+            return Task.FromResult(MavResult.MavResultAccepted);
+        };
+        
         var nameArray = new byte[SdrWellKnown.RecordTagValueMaxLength];
         var mavResult = await asvSdrClientEx.CurrentRecordSetTag("test", AsvSdrRecordTagType.AsvSdrRecordTagTypeString8, nameArray, CancellationToken.None);
-        Assert.True(mavResult == MavResult.MavResultUnsupported);
+        Assert.True(mavResult == MavResult.MavResultAccepted);
     }
     
     [Fact]


### PR DESCRIPTION
Added server handlers to support recording actions in AsvSdrExTests. This includes StartRecord, StopRecord, and CurrentRecordSetTag. The changes were necessary to ensure record actions were accepted and not unsupported, thus resulting in passing tests.

Asana: https://app.asana.com/0/1203851531040615/1205007800629272/f