### PR TITLE
feat(mavlink): add ROI mission item to IMissionClientEx interface

### DIFF
--- a/src/Asv.Mavlink/Microservices/Missions/Client/Ex/IMissionClientEx.cs
+++ b/src/Asv.Mavlink/Microservices/Missions/Client/Ex/IMissionClientEx.cs
@@ -56,4 +56,19 @@ public static class MissionClientExHelper
         item.Param4.OnNext(0);
         return item;
     }
+    public static MissionItem AddRoiMissionItem(this IMissionClientEx vehicle, GeoPoint point)
+    {
+        var item = vehicle.Create();
+        item.Location.OnNext(point);
+        item.Autocontinue.OnNext(true);
+        item.Command.OnNext(MavCmd.MavCmdDoSetRoiLocation);
+        item.Current.OnNext(false);
+        item.Frame.OnNext(MavFrame.MavFrameGlobalInt);
+        item.MissionType.OnNext(MavMissionType.MavMissionTypeMission);
+        item.Param1.OnNext(0);
+        item.Param2.OnNext(0);
+        item.Param3.OnNext(0);
+        item.Param4.OnNext(0);
+        return item;
+    }
 }


### PR DESCRIPTION
In this update, a function was added to the IMissionClientEx interface to construct and add a Region of Interest (RoI) mission item. This function takes a GeoPoint, representing the coordinates of the RoI, generates the requisite mission item, and adds it to the mission queue. This feature was added to facilitate automatic drone navigation around a specific geographical point of interest.

Asana: https://app.asana.com/0/1203851531040615/1205237266324949/f