### PR TITLE
feat: add unit tests for FileSystemHierarchicalStore

### DIFF
--- a/src/Asv.Mavlink.Test/Tools/FileSystemHierarchicalStoreTest.cs
+++ b/src/Asv.Mavlink.Test/Tools/FileSystemHierarchicalStoreTest.cs
@@ -24,20 +24,21 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_Open_File_After_Disposed #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var firstGuid = Guid.NewGuid();
         var file = store.CreateFile(firstGuid, "FirstFile_OpenAfter", store.RootFolderId);
         file.Dispose();
 
-        var fs = File.Open($"TestFolder\\FirstFile_OpenAfter #{ShortGuid.Encode(firstGuid)}.sdr", FileMode.Open, FileAccess.Write);
+        var fs = File.Open($"{storeLocation}\\FirstFile_OpenAfter #{ShortGuid.Encode(firstGuid)}.sdr", FileMode.Open, FileAccess.Write);
         
         store.Dispose();
 
         Assert.Throws<IOException>(() =>
         {
-            File.Open($"TestFolder\\FirstFile_OpenAfter #{ShortGuid.Encode(firstGuid)}.sdr", FileMode.Open);
+            File.Open($"{storeLocation}\\FirstFile_OpenAfter #{ShortGuid.Encode(firstGuid)}.sdr", FileMode.Open);
         });
         
         fs.Close();
@@ -49,7 +50,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_Create_File_With_Same_Id #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var firstGuid = Guid.NewGuid();
@@ -65,9 +67,10 @@ public class FileSystemHierarchicalStoreTest
     public void Check_Success_Create_File()
     {
         ClearAllDirectories();
-        
+        var storeLocation = "TestFolder_Success_CreateFile #" + Path.GetRandomFileName();
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid = Guid.NewGuid();
@@ -75,9 +78,9 @@ public class FileSystemHierarchicalStoreTest
         var file = store.CreateFile(guid, "FirstCreation", store.RootFolderId);
         file.Dispose();
         
-        var files = Directory.GetFiles("TestFolder");
+        var files = Directory.GetFiles(storeLocation);
         
-        Assert.True(files[0].Equals($"TestFolder\\FirstCreation #{ShortGuid.Encode(guid)}.sdr"));
+        Assert.True(files[0].Equals($"{storeLocation}\\FirstCreation #{ShortGuid.Encode(guid)}.sdr"));
         store.Dispose();
     }
 
@@ -87,19 +90,20 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_Manual_File_Delete #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
     
         var guid = Guid.NewGuid();
         
         var file = store.CreateFile(guid, "FirstCreation", store.RootFolderId);
         file.Dispose();
-        var files = Directory.GetFiles("TestFolder");
+        var files = Directory.GetFiles(storeLocation);
     
         File.Delete(files[0]);
         store.Dispose();
         
-        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var storeFiles = store.GetFiles();
@@ -113,12 +117,13 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_GetFiles #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid = Guid.NewGuid();
         
-        var file1 = store.CreateFile(guid, "FirstFile_GetFiles", store.RootFolderId);
+        var file1 = store.CreateFile(guid, "FirstFile", store.RootFolderId);
         file1.Dispose();
         var file2 = store.CreateFile(Guid.NewGuid(), "SecondFile", store.RootFolderId);
         file2.Dispose();
@@ -142,14 +147,15 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_TryGetFile #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
         var guid2 = Guid.NewGuid();
         var guid3 = Guid.NewGuid();
         
-        var file1 = store.CreateFile(guid1, "FirstFile_TryGetFile", store.RootFolderId);
+        var file1 = store.CreateFile(guid1, "FirstFile", store.RootFolderId);
         file1.Dispose();
         var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
         file2.Dispose();
@@ -170,14 +176,15 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_DeleteFile #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
         var guid2 = Guid.NewGuid();
         var folderGuid = Guid.NewGuid();
         
-        var file1 = store.CreateFile(guid1, "FirstFile_DeleteFile", store.RootFolderId);
+        var file1 = store.CreateFile(guid1, "FirstFile", store.RootFolderId);
         file1.Dispose();
         var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
         
@@ -210,14 +217,15 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_RenameFile #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
         var guid2 = Guid.NewGuid();
         var folderGuid = Guid.NewGuid();
         
-        var file1 = store.CreateFile(guid1, "FirstFile_RenameFile", store.RootFolderId);
+        var file1 = store.CreateFile(guid1, "FirstFile", store.RootFolderId);
         file1.Dispose();
         var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
         var folder1 = store.CreateFolder(folderGuid, "FirstFolder", store.RootFolderId);
@@ -236,7 +244,7 @@ public class FileSystemHierarchicalStoreTest
         
         Assert.Equal(guid1, store.RenameFile(guid1, "NewFirstFileName"));
         
-        Assert.True(File.Exists($"TestFolder\\NewFirstFileName #{ShortGuid.Encode(guid1)}.sdr"));
+        Assert.True(File.Exists($"{storeLocation}\\NewFirstFileName #{ShortGuid.Encode(guid1)}.sdr"));
         
         store.Dispose();
     }
@@ -247,7 +255,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_MoveFile #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
@@ -256,7 +265,7 @@ public class FileSystemHierarchicalStoreTest
         var folderGuid = Guid.NewGuid();
         var newFolderGuid = Guid.NewGuid();
         
-        var file1 = store.CreateFile(guid1, "FirstFile_MoveFile", store.RootFolderId);
+        var file1 = store.CreateFile(guid1, "FirstFile", store.RootFolderId);
         file1.Dispose();
         var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
         file2.Dispose();
@@ -284,7 +293,7 @@ public class FileSystemHierarchicalStoreTest
         
         store.MoveFile(guid1, folderGuid);
         
-        Assert.True(File.Exists($"TestFolder\\FirstFolder #{ShortGuid.Encode(folderGuid)}\\FirstFile_MoveFile #{ShortGuid.Encode(guid1)}.sdr"));
+        Assert.True(File.Exists($"{storeLocation}\\FirstFolder #{ShortGuid.Encode(folderGuid)}\\FirstFile #{ShortGuid.Encode(guid1)}.sdr"));
         
         store.Dispose();
     }
@@ -295,14 +304,15 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_OpenFile #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(100));
 
         var guid1 = Guid.NewGuid();
         var guid2 = Guid.NewGuid();
         var guid3 = Guid.NewGuid();
         
-        var file1 = store.CreateFile(guid1, "FirstFile_OpenFile", store.RootFolderId);
+        var file1 = store.CreateFile(guid1, "FirstFile", store.RootFolderId);
         file1.Dispose();
         var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
         file2.Dispose();
@@ -318,16 +328,15 @@ public class FileSystemHierarchicalStoreTest
 
         Observable.Timer(TimeSpan.FromMilliseconds(150)).Subscribe(_ =>
         {
-            File.Delete($"TestFolder\\SecondFile #{ShortGuid.Encode(guid2)}.sdr");
+            File.Delete($"{storeLocation}\\SecondFile #{ShortGuid.Encode(guid2)}.sdr");
 
             Assert.Throws<FileNotFoundException>(() =>
             {
                 store.OpenFile(guid2);
             });
             
-            ClearAllDirectories();
+            store.Dispose();
         });
-        store.Dispose();
     }
     
     #endregion
@@ -340,7 +349,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_GetFolders #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
@@ -366,7 +376,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_Folder_Manual_Delete #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
@@ -379,9 +390,9 @@ public class FileSystemHierarchicalStoreTest
         
         Assert.Equal(2, folders.Count);
         
-        Directory.Delete($"TestFolder\\SecondFolder #{ShortGuid.Encode(guid2)}");
+        Directory.Delete($"{storeLocation}\\SecondFolder #{ShortGuid.Encode(guid2)}");
         store.Dispose();
-        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
         folders = store.GetFolders();
         
@@ -395,7 +406,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_CreateFolder #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
@@ -433,7 +445,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_DeleteFolder #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
@@ -465,11 +478,11 @@ public class FileSystemHierarchicalStoreTest
         
         file2.Dispose();
 
-        var files = Directory.GetDirectories("TestFolder");
+        var files = Directory.GetDirectories(storeLocation);
         Assert.Equal(2, files.Length);
         
         store.DeleteFolder(guid2);
-        files = Directory.GetDirectories("TestFolder");
+        files = Directory.GetDirectories(storeLocation);
         Assert.Single(files);
         
         store.Dispose();
@@ -481,7 +494,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_FolderExists #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(100));
 
         var guid1 = Guid.NewGuid();
@@ -492,10 +506,10 @@ public class FileSystemHierarchicalStoreTest
         
         Assert.True(store.FolderExists(guid1));
         
-        Directory.Delete($"TestFolder\\SecondFolder #{ShortGuid.Encode(guid2)}");
+        Directory.Delete($"{storeLocation}\\SecondFolder #{ShortGuid.Encode(guid2)}");
         store.Dispose();
         
-        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(100));
 
         Observable.Timer(TimeSpan.FromMilliseconds(150)).Subscribe(_ =>
@@ -512,7 +526,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_RenameFolder #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
@@ -546,11 +561,11 @@ public class FileSystemHierarchicalStoreTest
         
         file2.Dispose();
         
-        Assert.True(Directory.Exists($"TestFolder\\SecondFolder #{ShortGuid.Encode(folder2)}"));
+        Assert.True(Directory.Exists($"{storeLocation}\\SecondFolder #{ShortGuid.Encode(folder2)}"));
         
         store.RenameFolder(folder2, "NewSecondFolder");
         
-        Assert.True(Directory.Exists($"TestFolder\\NewSecondFolder #{ShortGuid.Encode(folder2)}"));
+        Assert.True(Directory.Exists($"{storeLocation}\\NewSecondFolder #{ShortGuid.Encode(folder2)}"));
         
         store.Dispose();
     }
@@ -561,7 +576,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_MoveFolder #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var guid1 = Guid.NewGuid();
@@ -594,11 +610,11 @@ public class FileSystemHierarchicalStoreTest
             store.MoveFolder(folder1, guid3);
         });
         
-        Assert.True(Directory.Exists($"TestFolder\\SecondFolder #{ShortGuid.Encode(folder2)}"));
+        Assert.True(Directory.Exists($"{storeLocation}\\SecondFolder #{ShortGuid.Encode(folder2)}"));
         
         store.MoveFolder(folder2, folder1);
         
-        Assert.True(Directory.Exists($"TestFolder\\FirstFolder #{ShortGuid.Encode(folder1)}\\SecondFolder #{ShortGuid.Encode(folder2)}"));
+        Assert.True(Directory.Exists($"{storeLocation}\\FirstFolder #{ShortGuid.Encode(folder1)}\\SecondFolder #{ShortGuid.Encode(folder2)}"));
         store.Dispose();
     }
 
@@ -612,7 +628,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_GetEntries #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var fileGuid1 = Guid.NewGuid();
@@ -661,7 +678,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_TryGetEntry #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
         
         var fileGuid1 = Guid.NewGuid();
@@ -701,7 +719,8 @@ public class FileSystemHierarchicalStoreTest
         ClearAllDirectories();
         
         var format = new AsvSdrListDataStoreFormat();
-        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+        var storeLocation = "TestFolder_EntryExists #" + Path.GetRandomFileName();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(0));
 
         var fileGuid1 = Guid.NewGuid();

--- a/src/Asv.Mavlink.Test/Tools/FileSystemHierarchicalStoreTest.cs
+++ b/src/Asv.Mavlink.Test/Tools/FileSystemHierarchicalStoreTest.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using System.Reactive.Linq;
+using System.Threading.Tasks;
 using Asv.Common;
 using Xunit;
 
@@ -8,11 +8,11 @@ namespace Asv.Mavlink.Test;
 
 public class FileSystemHierarchicalStoreTest
 {
-    private void ClearAllDirectories()
+    private static void ClearAllDirectories(string storeLocation)
     {
-        if (Directory.Exists("TestFolder"))
+        if (Directory.Exists(storeLocation))
         {
-            Directory.Delete("TestFolder", true);
+            Directory.Delete(storeLocation, true);
         }
     }
     
@@ -21,8 +21,6 @@ public class FileSystemHierarchicalStoreTest
     [Fact]
     public void Check_File_Open_After_Store_Was_Disposed()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_Open_File_After_Disposed #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -42,13 +40,13 @@ public class FileSystemHierarchicalStoreTest
         });
         
         fs.Close();
+        
+        ClearAllDirectories(storeLocation);
     }
     
     [Fact]
     public void Check_Create_File_With_Same_Id()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_Create_File_With_Same_Id #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -61,12 +59,13 @@ public class FileSystemHierarchicalStoreTest
 
         Assert.Throws<HierarchicalStoreException>(() => store.CreateFile(firstGuid, "SecondCreation", store.RootFolderId));
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_Success_Create_File()
     {
-        ClearAllDirectories();
         var storeLocation = "TestFolder_Success_CreateFile #" + Path.GetRandomFileName();
         var format = new AsvSdrListDataStoreFormat();
         
@@ -82,13 +81,13 @@ public class FileSystemHierarchicalStoreTest
         
         Assert.True(files[0].Equals($"{storeLocation}\\FirstCreation #{ShortGuid.Encode(guid)}.sdr"));
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_If_File_Exists_After_Manual_Delete()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_Manual_File_Delete #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -109,13 +108,13 @@ public class FileSystemHierarchicalStoreTest
         var storeFiles = store.GetFiles();
         Assert.True(storeFiles.Count == 0);
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_GetFiles()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_GetFiles #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -139,13 +138,13 @@ public class FileSystemHierarchicalStoreTest
         
         Assert.True(files.Count == 2);
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_TryGetFile()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_TryGetFile #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -168,13 +167,13 @@ public class FileSystemHierarchicalStoreTest
         store.DeleteFile(guid1);
         Assert.False(store.TryGetFile(guid1, out _));
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_DeleteFile()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_DeleteFile #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -209,13 +208,13 @@ public class FileSystemHierarchicalStoreTest
         Assert.False(store.FileExists(guid1));
         
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_RenameFile()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_RenameFile #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -247,13 +246,13 @@ public class FileSystemHierarchicalStoreTest
         Assert.True(File.Exists($"{storeLocation}\\NewFirstFileName #{ShortGuid.Encode(guid1)}.sdr"));
         
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_MoveFile()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_MoveFile #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -296,13 +295,13 @@ public class FileSystemHierarchicalStoreTest
         Assert.True(File.Exists($"{storeLocation}\\FirstFolder #{ShortGuid.Encode(folderGuid)}\\FirstFile #{ShortGuid.Encode(guid1)}.sdr"));
         
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
-    public void Check_OpenFile()
+    public async void Check_OpenFile()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_OpenFile #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -326,17 +325,18 @@ public class FileSystemHierarchicalStoreTest
             store.OpenFile(guid3);
         });
 
-        Observable.Timer(TimeSpan.FromMilliseconds(150)).Subscribe(_ =>
-        {
-            File.Delete($"{storeLocation}\\SecondFile #{ShortGuid.Encode(guid2)}.sdr");
+        await Task.Delay(250);
 
-            Assert.Throws<FileNotFoundException>(() =>
-            {
-                store.OpenFile(guid2);
-            });
-            
-            store.Dispose();
+        File.Delete($"{storeLocation}\\SecondFile #{ShortGuid.Encode(guid2)}.sdr");
+
+        Assert.Throws<FileNotFoundException>(() =>
+        {
+            store.OpenFile(guid2);
         });
+            
+        store.Dispose();
+
+        ClearAllDirectories(storeLocation);
     }
     
     #endregion
@@ -346,8 +346,6 @@ public class FileSystemHierarchicalStoreTest
     [Fact]
     public void Check_GetFolders()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_GetFolders #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -368,13 +366,13 @@ public class FileSystemHierarchicalStoreTest
         
         Assert.Equal(1, folders.Count);
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
     
     [Fact]
     public void Check_Manual_Delete_GetFolders()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_Folder_Manual_Delete #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -398,13 +396,13 @@ public class FileSystemHierarchicalStoreTest
         
         Assert.Equal(1, folders.Count);
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_CreateFolder()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_CreateFolder #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -437,13 +435,13 @@ public class FileSystemHierarchicalStoreTest
             store.CreateFolder(guid3, "ThirdFolder", guid4);
         });
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_DeleteFolder()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_DeleteFolder #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -486,13 +484,13 @@ public class FileSystemHierarchicalStoreTest
         Assert.Single(files);
         
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
-    public void Check_FolderExists()
+    public async void Check_FolderExists()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_FolderExists #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -512,19 +510,17 @@ public class FileSystemHierarchicalStoreTest
         store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
             TimeSpan.FromMilliseconds(100));
 
-        Observable.Timer(TimeSpan.FromMilliseconds(150)).Subscribe(_ =>
-        {
-            Assert.False(store.FolderExists(guid2));
-            store.Dispose();
-            ClearAllDirectories();
-        });
+        await Task.Delay(250);
+
+        Assert.False(store.FolderExists(guid2));
+        store.Dispose();
+            
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_RenameFolder()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_RenameFolder #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -568,13 +564,13 @@ public class FileSystemHierarchicalStoreTest
         Assert.True(Directory.Exists($"{storeLocation}\\NewSecondFolder #{ShortGuid.Encode(folder2)}"));
         
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_MoveFolder()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_MoveFolder #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -616,6 +612,8 @@ public class FileSystemHierarchicalStoreTest
         
         Assert.True(Directory.Exists($"{storeLocation}\\FirstFolder #{ShortGuid.Encode(folder1)}\\SecondFolder #{ShortGuid.Encode(folder2)}"));
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     #endregion
@@ -625,8 +623,6 @@ public class FileSystemHierarchicalStoreTest
     [Fact]
     public void Check_GetEntries()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_GetEntries #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -670,13 +666,13 @@ public class FileSystemHierarchicalStoreTest
         Assert.Equal(1, entries.Count);
         
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_TryGetEntry()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_TryGetEntry #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -711,13 +707,13 @@ public class FileSystemHierarchicalStoreTest
         Assert.False(store.TryGetEntry(folderGuid1, out _));
         
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     [Fact]
     public void Check_EntryExists()
     {
-        ClearAllDirectories();
-        
         var format = new AsvSdrListDataStoreFormat();
         var storeLocation = "TestFolder_EntryExists #" + Path.GetRandomFileName();
         var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
@@ -753,6 +749,8 @@ public class FileSystemHierarchicalStoreTest
         Assert.False(store.EntryExists(folderGuid1));
         
         store.Dispose();
+        
+        ClearAllDirectories(storeLocation);
     }
 
     #endregion

--- a/src/Asv.Mavlink.Test/Tools/FileSystemHierarchicalStoreTest.cs
+++ b/src/Asv.Mavlink.Test/Tools/FileSystemHierarchicalStoreTest.cs
@@ -1,0 +1,740 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using Asv.Common;
+using Xunit;
+
+namespace Asv.Mavlink.Test;
+
+public class FileSystemHierarchicalStoreTest
+{
+    private void ClearAllDirectories()
+    {
+        if (Directory.Exists("TestFolder"))
+        {
+            Directory.Delete("TestFolder", true);
+        }
+    }
+    
+    #region Files
+
+    [Fact]
+    public void Check_File_Open_After_Store_Was_Disposed()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var firstGuid = Guid.NewGuid();
+        var file = store.CreateFile(firstGuid, "FirstFile_OpenAfter", store.RootFolderId);
+        file.Dispose();
+
+        var fs = File.Open($"TestFolder\\FirstFile_OpenAfter #{ShortGuid.Encode(firstGuid)}.sdr", FileMode.Open, FileAccess.Write);
+        
+        store.Dispose();
+
+        Assert.Throws<IOException>(() =>
+        {
+            File.Open($"TestFolder\\FirstFile_OpenAfter #{ShortGuid.Encode(firstGuid)}.sdr", FileMode.Open);
+        });
+        
+        fs.Close();
+    }
+    
+    [Fact]
+    public void Check_Create_File_With_Same_Id()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var firstGuid = Guid.NewGuid();
+        
+        var file = store.CreateFile(firstGuid, "FirstCreation", store.RootFolderId);
+        file.Dispose();
+
+        Assert.Throws<HierarchicalStoreException>(() => store.CreateFile(firstGuid, "SecondCreation", store.RootFolderId));
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_Success_Create_File()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid = Guid.NewGuid();
+        
+        var file = store.CreateFile(guid, "FirstCreation", store.RootFolderId);
+        file.Dispose();
+        
+        var files = Directory.GetFiles("TestFolder");
+        
+        Assert.True(files[0].Equals($"TestFolder\\FirstCreation #{ShortGuid.Encode(guid)}.sdr"));
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_If_File_Exists_After_Manual_Delete()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+    
+        var guid = Guid.NewGuid();
+        
+        var file = store.CreateFile(guid, "FirstCreation", store.RootFolderId);
+        file.Dispose();
+        var files = Directory.GetFiles("TestFolder");
+    
+        File.Delete(files[0]);
+        store.Dispose();
+        
+        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var storeFiles = store.GetFiles();
+        Assert.True(storeFiles.Count == 0);
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_GetFiles()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid = Guid.NewGuid();
+        
+        var file1 = store.CreateFile(guid, "FirstFile_GetFiles", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(Guid.NewGuid(), "SecondFile", store.RootFolderId);
+        file2.Dispose();
+        var file3 = store.CreateFile(Guid.NewGuid(), "ThirdFileFile", store.RootFolderId);
+        file3.Dispose();
+
+        var files = store.GetFiles();
+        
+        Assert.True(files.Count == 3);
+        
+        store.DeleteFile(guid);
+        files = store.GetFiles();
+        
+        Assert.True(files.Count == 2);
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_TryGetFile()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+        
+        var file1 = store.CreateFile(guid1, "FirstFile_TryGetFile", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
+        file2.Dispose();
+        var file3 = store.CreateFile(guid3, "ThirdFileFile", store.RootFolderId);
+        file3.Dispose();
+        
+        Assert.True(store.TryGetFile(guid1, out _));
+        Assert.True(store.TryGetFile(guid2, out _));
+        Assert.True(store.TryGetFile(guid3, out _));
+        store.DeleteFile(guid1);
+        Assert.False(store.TryGetFile(guid1, out _));
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_DeleteFile()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var folderGuid = Guid.NewGuid();
+        
+        var file1 = store.CreateFile(guid1, "FirstFile_DeleteFile", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
+        
+        var file3 = store.CreateFile(Guid.NewGuid(), "ThirdFileFile", store.RootFolderId);
+        file3.Dispose();
+        var folder1 = store.CreateFolder(folderGuid, "FirstFolder", store.RootFolderId);
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.DeleteFile(folderGuid);
+        });
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.DeleteFile(guid2);
+        });
+        
+        file2.Dispose();
+        
+        Assert.True(store.FileExists(guid1));
+        store.DeleteFile(guid1);
+        Assert.False(store.FileExists(guid1));
+        
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_RenameFile()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var folderGuid = Guid.NewGuid();
+        
+        var file1 = store.CreateFile(guid1, "FirstFile_RenameFile", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
+        var folder1 = store.CreateFolder(folderGuid, "FirstFolder", store.RootFolderId);
+        
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.RenameFile(folderGuid, "NewFolderName");
+        });
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.RenameFile(guid2, "NewFileName");
+        });
+        
+        file2.Dispose();
+        
+        Assert.Equal(guid1, store.RenameFile(guid1, "NewFirstFileName"));
+        
+        Assert.True(File.Exists($"TestFolder\\NewFirstFileName #{ShortGuid.Encode(guid1)}.sdr"));
+        
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_MoveFile()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+        var folderGuid = Guid.NewGuid();
+        var newFolderGuid = Guid.NewGuid();
+        
+        var file1 = store.CreateFile(guid1, "FirstFile_MoveFile", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
+        file2.Dispose();
+        var file3 = store.CreateFile(guid3, "ThirdFile", store.RootFolderId);
+        
+        var folder1 = store.CreateFolder(folderGuid, "FirstFolder", store.RootFolderId);
+        var folder2 = store.CreateFolder(newFolderGuid, "SecondFolder", store.RootFolderId);
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.MoveFile(folderGuid, newFolderGuid);
+        });
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.MoveFile(guid1, guid2);
+        });
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.MoveFile(guid3, folderGuid);
+        });
+        
+        file3.Dispose();
+        
+        store.MoveFile(guid1, folderGuid);
+        
+        Assert.True(File.Exists($"TestFolder\\FirstFolder #{ShortGuid.Encode(folderGuid)}\\FirstFile_MoveFile #{ShortGuid.Encode(guid1)}.sdr"));
+        
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_OpenFile()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(100));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+        
+        var file1 = store.CreateFile(guid1, "FirstFile_OpenFile", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(guid2, "SecondFile", store.RootFolderId);
+        file2.Dispose();
+
+        var resultFile = store.OpenFile(guid1);
+        resultFile.Dispose();
+        Assert.Equal(resultFile.Id, guid1);
+
+        Assert.Throws<FileNotFoundException>(() =>
+        {
+            store.OpenFile(guid3);
+        });
+
+        Observable.Timer(TimeSpan.FromMilliseconds(150)).Subscribe(_ =>
+        {
+            File.Delete($"TestFolder\\SecondFile #{ShortGuid.Encode(guid2)}.sdr");
+
+            Assert.Throws<FileNotFoundException>(() =>
+            {
+                store.OpenFile(guid2);
+            });
+            
+            ClearAllDirectories();
+        });
+        store.Dispose();
+    }
+    
+    #endregion
+
+    #region Folders
+
+    [Fact]
+    public void Check_GetFolders()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+
+        store.CreateFolder(guid1, "FirstFolder", store.RootFolderId);
+        store.CreateFolder(guid2, "SecondFolder", store.RootFolderId);
+
+        var folders = store.GetFolders();
+        
+        Assert.Equal(2, folders.Count);
+        
+        store.DeleteFolder(guid2);
+        folders = store.GetFolders();
+        
+        Assert.Equal(1, folders.Count);
+        store.Dispose();
+    }
+    
+    [Fact]
+    public void Check_Manual_Delete_GetFolders()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+
+        store.CreateFolder(guid1, "FirstFolder", store.RootFolderId);
+        store.CreateFolder(guid2, "SecondFolder", store.RootFolderId);
+
+        var folders = store.GetFolders();
+        
+        Assert.Equal(2, folders.Count);
+        
+        Directory.Delete($"TestFolder\\SecondFolder #{ShortGuid.Encode(guid2)}");
+        store.Dispose();
+        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+        folders = store.GetFolders();
+        
+        Assert.Equal(1, folders.Count);
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_CreateFolder()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+
+        var folder1 = store.CreateFolder(guid1, "FirstFolder", store.RootFolderId);
+        var folder2 = store.CreateFolder(guid2, "SecondFolder", store.RootFolderId);
+
+        Assert.Throws<HierarchicalStoreFolderAlreadyExistException>(() =>
+        {
+            store.CreateFolder(guid1, "ThirdFolder", store.RootFolderId);
+        });
+
+        Assert.Throws<HierarchicalStoreFolderAlreadyExistException>(() =>
+        {
+            store.CreateFolder(Guid.NewGuid(), "FirstFolder", store.RootFolderId);
+        });
+        
+        Assert.Equal(guid1, folder1);
+        Assert.Equal(guid2, folder2);
+
+        var guid3 = Guid.NewGuid();
+        var guid4 = Guid.NewGuid();
+        
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.CreateFolder(guid3, "ThirdFolder", guid4);
+        });
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_DeleteFolder()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+        var fileGuid1 = Guid.NewGuid();
+        var fileGuid2 = Guid.NewGuid();
+
+        var folder1 = store.CreateFolder(guid1, "FirstFolder", store.RootFolderId);
+        var folder2 = store.CreateFolder(guid2, "SecondFolder", store.RootFolderId);
+        var file1 = store.CreateFile(fileGuid1, "FirstFile_DeleteFolder", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(fileGuid2, "SecondFile", folder1);
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.DeleteFolder(guid3);
+        });
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.DeleteFolder(fileGuid1);
+        });
+        
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.DeleteFolder(guid1);
+        });
+        
+        file2.Dispose();
+
+        var files = Directory.GetDirectories("TestFolder");
+        Assert.Equal(2, files.Length);
+        
+        store.DeleteFolder(guid2);
+        files = Directory.GetDirectories("TestFolder");
+        Assert.Single(files);
+        
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_FolderExists()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(100));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+
+        var folder1 = store.CreateFolder(guid1, "FirstFolder", store.RootFolderId);
+        var folder2 = store.CreateFolder(guid2, "SecondFolder", store.RootFolderId);
+        
+        Assert.True(store.FolderExists(guid1));
+        
+        Directory.Delete($"TestFolder\\SecondFolder #{ShortGuid.Encode(guid2)}");
+        store.Dispose();
+        
+        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(100));
+
+        Observable.Timer(TimeSpan.FromMilliseconds(150)).Subscribe(_ =>
+        {
+            Assert.False(store.FolderExists(guid2));
+            store.Dispose();
+            ClearAllDirectories();
+        });
+    }
+
+    [Fact]
+    public void Check_RenameFolder()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+
+        var folder1 = store.CreateFolder(guid1, "FirstFolder", store.RootFolderId);
+        var folder2 = store.CreateFolder(guid2, "SecondFolder", store.RootFolderId);
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.RenameFolder(guid3, "ThirdFolder");
+        });
+
+        var file1 = store.CreateFile(guid3, "FirstFile_RenameFolder", store.RootFolderId);
+        file1.Dispose();
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.RenameFolder(guid3, "ThirdFolder");
+        });
+        
+        store.DeleteFile(guid3);
+
+        var file2 = store.CreateFile(guid3, "SecondFile", folder1);
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.RenameFolder(folder1, "NewFirstFolder");
+        });
+        
+        file2.Dispose();
+        
+        Assert.True(Directory.Exists($"TestFolder\\SecondFolder #{ShortGuid.Encode(folder2)}"));
+        
+        store.RenameFolder(folder2, "NewSecondFolder");
+        
+        Assert.True(Directory.Exists($"TestFolder\\NewSecondFolder #{ShortGuid.Encode(folder2)}"));
+        
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_MoveFolder()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var guid1 = Guid.NewGuid();
+        var guid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+
+        var folder1 = store.CreateFolder(guid1, "FirstFolder", store.RootFolderId);
+        var folder2 = store.CreateFolder(guid2, "SecondFolder", store.RootFolderId);
+        
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.MoveFolder(guid3, folder1);
+        });
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.MoveFolder(folder1, guid3);
+        });
+
+        var file1 = store.CreateFile(guid3, "FirstFile_MoveFolder", store.RootFolderId);
+        file1.Dispose();
+
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.MoveFolder(guid3, folder1);
+        });
+        
+        Assert.Throws<HierarchicalStoreException>(() =>
+        {
+            store.MoveFolder(folder1, guid3);
+        });
+        
+        Assert.True(Directory.Exists($"TestFolder\\SecondFolder #{ShortGuid.Encode(folder2)}"));
+        
+        store.MoveFolder(folder2, folder1);
+        
+        Assert.True(Directory.Exists($"TestFolder\\FirstFolder #{ShortGuid.Encode(folder1)}\\SecondFolder #{ShortGuid.Encode(folder2)}"));
+        store.Dispose();
+    }
+
+    #endregion
+
+    #region Entries
+
+    [Fact]
+    public void Check_GetEntries()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var fileGuid1 = Guid.NewGuid();
+        var fileGuid2 = Guid.NewGuid();
+        var folderGuid1 = Guid.NewGuid();
+        var folderGuid2 = Guid.NewGuid();
+
+        var file1 = store.CreateFile(fileGuid1, "FirstFile_GetEntries", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(fileGuid2, "SecondFile", store.RootFolderId);
+        file2.Dispose();
+
+        store.CreateFolder(folderGuid1, "FirstFolder", store.RootFolderId);
+        store.CreateFolder(folderGuid2, "SecondFolder", store.RootFolderId);
+
+        var entries = store.GetEntries();
+        
+        Assert.Equal(4, entries.Count);
+        
+        store.DeleteFile(fileGuid1);
+        entries = store.GetEntries();
+        
+        Assert.Equal(3, entries.Count);
+        
+        store.MoveFile(fileGuid2, folderGuid1);
+        entries = store.GetEntries();
+        
+        Assert.Equal(3, entries.Count);
+        
+        store.DeleteFile(fileGuid2);
+        entries = store.GetEntries();
+        
+        Assert.Equal(2, entries.Count);
+        
+        store.DeleteFolder(folderGuid1);
+        entries = store.GetEntries();
+        
+        Assert.Equal(1, entries.Count);
+        
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_TryGetEntry()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+        
+        var fileGuid1 = Guid.NewGuid();
+        var fileGuid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+        var folderGuid1 = Guid.NewGuid();
+        var folderGuid2 = Guid.NewGuid();
+
+        var file1 = store.CreateFile(fileGuid1, "FirstFile_TryGetEntry", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(fileGuid2, "SecondFile", store.RootFolderId);
+        file2.Dispose();
+
+        store.CreateFolder(folderGuid1, "FirstFolder", store.RootFolderId);
+        store.CreateFolder(folderGuid2, "SecondFolder", store.RootFolderId);
+        
+        Assert.True(store.TryGetEntry(fileGuid1, out _));
+        Assert.True(store.TryGetEntry(fileGuid2, out _));
+        Assert.True(store.TryGetEntry(folderGuid1, out _));
+        Assert.True(store.TryGetEntry(folderGuid2, out _));
+        Assert.False(store.TryGetEntry(guid3, out _));
+        
+        store.DeleteFile(fileGuid1);
+        
+        Assert.False(store.TryGetEntry(fileGuid1, out _));
+        
+        store.DeleteFolder(folderGuid1);
+        
+        Assert.False(store.TryGetEntry(folderGuid1, out _));
+        
+        store.Dispose();
+    }
+
+    [Fact]
+    public void Check_EntryExists()
+    {
+        ClearAllDirectories();
+        
+        var format = new AsvSdrListDataStoreFormat();
+        var store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>("TestFolder", format,
+            TimeSpan.FromMilliseconds(0));
+
+        var fileGuid1 = Guid.NewGuid();
+        var fileGuid2 = Guid.NewGuid();
+        var guid3 = Guid.NewGuid();
+        var folderGuid1 = Guid.NewGuid();
+        var folderGuid2 = Guid.NewGuid();
+
+        var file1 = store.CreateFile(fileGuid1, "FirstFile_EntryExists", store.RootFolderId);
+        file1.Dispose();
+        var file2 = store.CreateFile(fileGuid2, "SecondFile", store.RootFolderId);
+        file2.Dispose();
+
+        store.CreateFolder(folderGuid1, "FirstFolder", store.RootFolderId);
+        store.CreateFolder(folderGuid2, "SecondFolder", store.RootFolderId);
+        
+        Assert.True(store.EntryExists(fileGuid1));
+        Assert.True(store.EntryExists(fileGuid2));
+        Assert.False(store.EntryExists(guid3));
+        
+        store.DeleteFile(fileGuid1);
+        
+        Assert.False(store.EntryExists(fileGuid1));
+        
+        Assert.True(store.EntryExists(folderGuid1));
+        Assert.True(store.EntryExists(folderGuid2));
+        
+        store.DeleteFolder(folderGuid1);
+        
+        Assert.False(store.EntryExists(folderGuid1));
+        
+        store.Dispose();
+    }
+
+    #endregion
+}

--- a/src/Asv.Mavlink/Tools/HierarchicalStore/IHierarchicalStore.cs
+++ b/src/Asv.Mavlink/Tools/HierarchicalStore/IHierarchicalStore.cs
@@ -16,7 +16,7 @@ public interface IHierarchicalStore<TKey, out TFile>: IDisposable
 
     IReadOnlyList<IHierarchicalStoreEntry<TKey>> GetEntries();
     bool TryGetEntry(TKey id, out IHierarchicalStoreEntry<TKey>? entry);
-    bool ExistEntry(TKey id);
+    bool EntryExists(TKey id);
 
     #endregion
     
@@ -26,7 +26,7 @@ public interface IHierarchicalStore<TKey, out TFile>: IDisposable
     IReadOnlyList<IHierarchicalStoreEntry<TKey>> GetFolders();
     TKey CreateFolder(TKey id, string name, TKey parentId);
     void DeleteFolder(TKey id);
-    bool ExistFolder(TKey id);
+    bool FolderExists(TKey id);
     void RenameFolder(TKey id, string newName);
     void MoveFolder(TKey id, TKey newParentId);
     
@@ -37,7 +37,7 @@ public interface IHierarchicalStore<TKey, out TFile>: IDisposable
     IReadOnlyList<IHierarchicalStoreEntry<TKey>> GetFiles();
     bool TryGetFile(TKey id, out IHierarchicalStoreEntry<TKey> entry);
     void DeleteFile(TKey id);
-    bool ExistFile(TKey id);
+    bool FileExists(TKey id);
     TKey RenameFile(TKey id, string newName);
     void MoveFile(TKey id, TKey newParentId);
     
@@ -45,8 +45,8 @@ public interface IHierarchicalStore<TKey, out TFile>: IDisposable
     
     #region Open/Create
 
-    ICachedFile<TKey, TFile> Open(TKey id);
-    ICachedFile<TKey, TFile> Create(TKey id, string name, TKey parentId);
+    ICachedFile<TKey, TFile> OpenFile(TKey id);
+    ICachedFile<TKey, TFile> CreateFile(TKey id, string name, TKey parentId);
 
     #endregion
 }


### PR DESCRIPTION
This pull request adds several unit tests for FileSystemHierarchicalStore. The tests cover operations including creating, renaming, moving, deleting for files and folders as well as various exceptions. They will ensure the correctness of our FileSystemHierarchicalStore's behavior and protect it from future changes that might break its current functionality.

Refactoring method names for better readability in HierarchicalStore. "Exist..." methods changed to "...Exists", "Open" and "Create" methods renamed to "OpenFile" and "CreateFile". Added error checking to prevent creation of a new file or folder when the specified parentId doesn't exist. Removed unnecessary use of file Id equals condition while trying to remove from the cache.

Asana: https://app.asana.com/0/1203851531040615/1205220481857538/f