### PR TITLE
fix: replace store.Dispose() with store.UpdateEntries()

### DIFF
--- a/src/Asv.Mavlink.Test/Tools/FileSystemHierarchicalStoreTest.cs
+++ b/src/Asv.Mavlink.Test/Tools/FileSystemHierarchicalStoreTest.cs
@@ -100,10 +100,8 @@ public class FileSystemHierarchicalStoreTest
         var files = Directory.GetFiles(storeLocation);
     
         File.Delete(files[0]);
-        store.Dispose();
         
-        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
-            TimeSpan.FromMilliseconds(0));
+        store.UpdateEntries();
 
         var storeFiles = store.GetFiles();
         Assert.True(storeFiles.Count == 0);
@@ -389,9 +387,9 @@ public class FileSystemHierarchicalStoreTest
         Assert.Equal(2, folders.Count);
         
         Directory.Delete($"{storeLocation}\\SecondFolder #{ShortGuid.Encode(guid2)}");
-        store.Dispose();
-        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
-            TimeSpan.FromMilliseconds(0));
+
+        store.UpdateEntries();
+        
         folders = store.GetFolders();
         
         Assert.Equal(1, folders.Count);
@@ -505,11 +503,9 @@ public class FileSystemHierarchicalStoreTest
         Assert.True(store.FolderExists(guid1));
         
         Directory.Delete($"{storeLocation}\\SecondFolder #{ShortGuid.Encode(guid2)}");
-        store.Dispose();
-        
-        store = new FileSystemHierarchicalStore<Guid, IListDataFile<AsvSdrRecordFileMetadata>>(storeLocation, format,
-            TimeSpan.FromMilliseconds(100));
 
+        store.UpdateEntries();
+        
         await Task.Delay(250);
 
         Assert.False(store.FolderExists(guid2));

--- a/src/Asv.Mavlink/Tools/HierarchicalStore/Impl/FileSystemHierarchicalStore.cs
+++ b/src/Asv.Mavlink/Tools/HierarchicalStore/Impl/FileSystemHierarchicalStore.cs
@@ -65,7 +65,7 @@ public class FileSystemHierarchicalStore<TKey, TFile>:DisposableOnceWithCancel,I
         _size = new RxValue<ulong>().DisposeItWith(Disposable);
         
         InternalUpdateEntries();
-
+        
         Disposable.AddAction(ClearFileCache);
 
     }
@@ -73,7 +73,14 @@ public class FileSystemHierarchicalStore<TKey, TFile>:DisposableOnceWithCancel,I
     public IRxValue<ushort> Count => _count;
     public IRxValue<ulong> Size => _size;
 
-
+    public void UpdateEntries()
+    {
+        lock (_sync)
+        {
+            InternalUpdateEntries();
+        }    
+    }
+    
     #region Internal update items
 
     /// <summary>


### PR DESCRIPTION
The change was made in FileSystemHierarchicalStoreTest.cs and FileSystemHierarchicalStore.cs. Disposing and recreating the store each time to reflect changes was redundant and could potentially cause issues. The method UpdateEntries() was introduced to resolve this by explicitly updating the entries within the store, improving efficiency and avoiding unnecessary object instantiations.

Asana: https://app.asana.com/0/1203851531040615/1205758515944602/f