### PR TITLE
fix: Add method to generate unique keys and handle duplicate file ent…

### DIFF
--- a/src/Asv.Mavlink/Tools/HierarchicalStore/Impl/GuidHierarchicalStoreFormat.cs
+++ b/src/Asv.Mavlink/Tools/HierarchicalStore/Impl/GuidHierarchicalStoreFormat.cs
@@ -115,6 +115,11 @@ public abstract class GuidHierarchicalStoreFormat<TFile> : IHierarchicalStoreFor
         }
     }
 
+    public Guid GenerateNewKey()
+    {
+        return Guid.NewGuid();
+    }
+
     public abstract void Dispose();
 
 }


### PR DESCRIPTION
…ries

A new method, `GenerateNewKey`, has been added to `GuidHierarchicalStoreFormat` class for creating unique keys as GUIDs. Made changes in `FileSystemHierarchicalStore` class to handle the scenario where multiple file entries might have same `Id`. If a duplicate Id is found, a new unique key is generated, the file is renamed accordingly and the new details are added to the entries. Also, a new test case 'Check_Update_Entries_With_Same_Id' has been added to handle this situation. These changes prevent duplicate entries from overwriting each other and ensure uniquely identifiable entries in the store.

Asana: https://app.asana.com/0/1203851531040615/1205990900963009/f