### PR TITLE
feat: add and remove methods for ServerMissionItems

### DIFF
--- a/src/Asv.Mavlink/Microservices/Missions/Server/Ex/IMissionServerEx.cs
+++ b/src/Asv.Mavlink/Microservices/Missions/Server/Ex/IMissionServerEx.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Asv.Common;
 using DynamicData;
 
@@ -10,4 +11,6 @@ public interface IMissionServerEx
    IRxEditableValue<ushort> Current { get; }
    IRxEditableValue<ushort> Reached { get; }
    IObservable<IChangeSet<ServerMissionItem,ushort>> Items { get; }
+   void AddItems(IEnumerable<ServerMissionItem> items);
+   void RemoveItems(IEnumerable<ServerMissionItem> items);
 }

--- a/src/Asv.Mavlink/Microservices/Missions/Server/Ex/MissionServerEx.cs
+++ b/src/Asv.Mavlink/Microservices/Missions/Server/Ex/MissionServerEx.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Threading;
 using Asv.Common;
@@ -121,5 +122,16 @@ public class MissionServerEx : MavlinkMicroserviceServer, IMissionServerEx
     public IRxEditableValue<ushort> Current { get; }
     public IRxEditableValue<ushort> Reached { get; }
     public IObservable<IChangeSet<ServerMissionItem, ushort>> Items => _missionSource.Connect();
+    public void AddItems(IEnumerable<ServerMissionItem> items)
+    {
+        if(items != null)
+            _missionSource.AddOrUpdate(items);
+    }
+
+    public void RemoveItems(IEnumerable<ServerMissionItem> items)
+    {
+        if(items != null)
+            _missionSource.Remove(items);
+    }
 }
 


### PR DESCRIPTION
Two new methods `AddItems` and `RemoveItems` were added to the `MissionServerEx` and `IMissionServerEx` classes. These changes were made for improving the interactions with mission items in the system, allowing more flexibility to add or remove missions as required by the program flow. A null check was also added to each method to ensure reliable execution. The system now has better control over managing mission items.

Asana: https://app.asana.com/0/1203851531040615/1206109097992726/f

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206187948272228