### PR TITLE
feat(asv-mavlink.shell): implementation of viewing the mission

### DIFF
--- a/src/Asv.Mavlink.Shell/Commands/DownloadMissionElements.cs
+++ b/src/Asv.Mavlink.Shell/Commands/DownloadMissionElements.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Asv.IO;
+using ConsoleAppFramework;
+using System.Threading;
+using Spectre.Console;
+
+namespace Asv.Mavlink.Shell;
+
+public class DownloadMissionElements
+{
+    /// <summary>
+    /// Selecting a device and uploading its missions
+    /// </summary>
+    /// <param name="connectionString">-cs, The address of the connection to the mavlink device</param>
+    /// <param name="iterations">-i, States how many iterations should the program work through</param>
+    /// <param name="devicesTimeout">-dt, (in seconds) States the lifetime of a mavlink device that shows no Heartbeat</param>
+    /// <param name="refreshRate">-r, (in ms) States how fast should the console be refreshed</param>
+    [Command("show-mission")]
+    public int RunShowMission(string connectionString = "tcp://127.0.0.1:5762", uint? iterations = null, uint devicesTimeout = 10, uint refreshRate = 3000)
+    {
+        ShellCommandsHelper.CreateDeviceExplorer(connectionString, out IDeviceExplorer deviceExplorer);
+        var Device = ShellCommandsHelper.DeviceAwaiter(deviceExplorer);
+        
+        if (Device.Microservices.FirstOrDefault(_ => _ is IMissionClient) is not IMissionClient missionClient)
+            return 0;
+        var mission = Device.Microservices.FirstOrDefault(_ => _ is MissionClient) as MissionClient; 
+        var count = mission.MissionRequestCount(new CancellationToken());
+        var table = new Table();
+        table.AddColumn("Mission ID");
+        table.AddColumn("Mission Name");
+        table.AddColumn("Mission IsCompleted");
+        table.AddColumn("Mission Status");
+        table.AddColumn("Mission Params");
+        
+        for (int i = 0; i < count.Result; i++)
+        {
+            var missionItem = mission.MissionRequestItem((ushort)i, new CancellationToken());
+            var missionParams = $"{missionItem.Result.Param1}, {missionItem.Result.Param2}, {missionItem.Result.Param3}, {missionItem.Result.Param4}";
+
+            table.AddRow(
+                missionItem.Id.ToString(),       
+                missionItem.GetType().Name,
+                // or missionItem.Result.MissionType.ToString(),
+                missionItem.IsCompleted ? "Completed" : "Not Completed",
+                missionItem.Status.ToString(),
+                missionParams
+            );
+        }
+        
+        AnsiConsole.Render(table);
+    
+        return 0;
+    }
+    
+}

--- a/src/Asv.Mavlink.Shell/Program.cs
+++ b/src/Asv.Mavlink.Shell/Program.cs
@@ -18,7 +18,7 @@ class Program
         /*app.Add<ExampleCommand>();
         //app.Add<FtpTreeDirectory>();
         //app.Add<FtpBrowserDirectory>();
-        app.Add<DevicesInfoCommand>();
+        
         app.Add<GenerateCommand>();
         app.Add<VirtualAdsbCommand>();
         app.Add<ExportSdrData>();
@@ -26,6 +26,7 @@ class Program
         app.Add<BenchmarkBinSerializationCommand>();
         app.Add<BenchmarkSerializationPacket>();*/
         //app.Add<ShowParams>();
+        app.Add<DevicesInfoCommand>();
         app.Add<MavlinkCommand>();
         app.Add<PacketViewerCommand>();
         app.Add<CreateVirtualFtpServerCommand>();
@@ -33,6 +34,7 @@ class Program
         app.Add<TestGenerateDiagnosticsCommand>();
         app.Add<PrintVehicleState>();
         app.Add<ParamsCommand>();
+        app.Add<DownloadMissionElements>();
         await app.RunAsync(args);
     }
 }

--- a/src/Asv.Mavlink.Shell/Properties/launchSettings.json
+++ b/src/Asv.Mavlink.Shell/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Asv.Mavlink.Shell": {
       "commandName": "Project",
-      "commandLineArgs": "print-vehicle-state"
+      "commandLineArgs": "show-mission -cs tcp://127.0.0.1:7341"
     }
   }
 }


### PR DESCRIPTION
Added the show-mission command to display information about Mavlink device missions.

- The RunShowMission method has been implemented to receive and display a list of device missions.
- A table from the Spectre library was used.Console for formatted output.
- Added columns: Mission ID, name, completion status, mission status and parameters.
- Added arguments for configuring connection, standby time, and refresh rate.

Asana: https://app.asana.com/0/1203851531040615/1209167728748398/f