### PR TITLE
 fix(sell-command)change-device-awaiter

### DIFF
--- a/src/Asv.Mavlink.Shell/Commands/DownloadMissionItemsCommand.cs
+++ b/src/Asv.Mavlink.Shell/Commands/DownloadMissionItemsCommand.cs
@@ -53,7 +53,7 @@ public class DownloadMissionItemsCommand
        ShellCommandsHelper.CreateDeviceExplorer(connectionString, out var deviceExplorer);
 
 
-       var device = ShellCommandsHelper.DeviceAwaiter(deviceExplorer);
+       var device = await ShellCommandsHelper.DeviceAwaiter(deviceExplorer);
 
 
        if (device.Microservices.FirstOrDefault(x => x is MissionClient) is not MissionClient mission)

--- a/src/Asv.Mavlink.Shell/Properties/launchSettings.json
+++ b/src/Asv.Mavlink.Shell/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Asv.Mavlink.Shell": {
       "commandName": "Project",
-      "commandLineArgs": "show-mission -cs  tcp://127.0.0.1:7341"
+      "commandLineArgs": "params"
     }
   }
 }

--- a/src/Asv.Mavlink.Shell/Tests/ParamsCommand.cs
+++ b/src/Asv.Mavlink.Shell/Tests/ParamsCommand.cs
@@ -71,14 +71,14 @@ namespace Asv.Mavlink.Shell
         /// </summary>
         /// <param name="connection">-connection, Connection string. Default "tcp://127.0.0.1:7341"</param>
         [Command("params")]
-        public int Run(string connection = "tcp://127.0.0.1:7341")
+        public async Task<int> Run(string connection = "tcp://127.0.0.1:7341")
         {
             AnsiConsole.Status().Start("CreateRouter", ctx =>
             {
                 ctx.SpinnerStyle(Style.Plain);
                 ShellCommandsHelper.CreateDeviceExplorer(connection, out _deviceExplorer);
             });
-            var selectedDevice = ShellCommandsHelper.DeviceAwaiter(_deviceExplorer);
+            var selectedDevice = await ShellCommandsHelper.DeviceAwaiter(_deviceExplorer);
             const string status = @"Waiting for init device";
             AnsiConsole.Status().StartAsync(status, statusContext =>
             {

--- a/src/Asv.Mavlink.Shell/Tests/PrintVehicleState.cs
+++ b/src/Asv.Mavlink.Shell/Tests/PrintVehicleState.cs
@@ -54,12 +54,12 @@ namespace Asv.Mavlink.Shell
         /// </summary>
         /// <param name="connection">-connection, Connection string. Default "tcp://127.0.0.1:7341"</param>
         [Command("print-vehicle-state")]
-        public int Run(string connection = "tcp://127.0.0.1:7341")
+        public async Task<int> Run(string connection = "tcp://127.0.0.1:7341")
         {
             ShellCommandsHelper.CreateDeviceExplorer(connection, out _deviceExplorer);
             while (_device is null)
             {
-                _device = ShellCommandsHelper.DeviceAwaiter(_deviceExplorer) as ArduCopterClientDevice;
+                _device = await ShellCommandsHelper.DeviceAwaiter(_deviceExplorer) as ArduCopterClientDevice;
                 if (_device is not null) continue;
                 AnsiConsole.Clear();
                 AnsiConsole.WriteLine("This command available only to MavType = 2 devices");

--- a/src/Asv.Mavlink.Shell/Tests/ShellCommandsHelper.cs
+++ b/src/Asv.Mavlink.Shell/Tests/ShellCommandsHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Asv.Cfg;
 using Asv.IO;
 using Microsoft.Extensions.Logging;
@@ -53,28 +54,39 @@ public static class ShellCommandsHelper
         }
     }
 
-    public static IClientDevice DeviceAwaiter(IDeviceExplorer deviceExplorer)
+    public static async Task<IClientDevice> DeviceAwaiter(IDeviceExplorer deviceExplorer)
     {
         var input = 0;
         var list = new List<IClientDevice>();
         var isChosen = false;
-        while (isChosen == false)
+
+        while (!isChosen)
         {
             AnsiConsole.Clear();
             var count = 1;
+            if (deviceExplorer.Devices.Count == 0)
+            {
+                await Task.Delay(2000);  
+                continue;  
+            }
+
             foreach (var device in deviceExplorer.Devices)
             {
                 AnsiConsole.WriteLine($@"{count}: {device.Key}");
                 count++;
             }
+            
+            input = AnsiConsole.Ask<int>("Select device or press 0 reload the list");
 
-            input = AnsiConsole.Ask<int>("Select device or press 0 to wait");
-            if (input == 0) continue;
-            isChosen = true;
+            if (input == 0)
+            {
+                continue; 
+            }
+            isChosen = true; 
             list.AddRange(deviceExplorer.Devices.Values);
         }
         AnsiConsole.Clear();
         return list[input - 1];
     }
-    
+
 }


### PR DESCRIPTION
Added handling for missing devices in DeviceAwaiter method:
- Added a check for an empty device list in `deviceExplorer.Devices`.
- If no devices are available, a message is displayed and a 2-second delay is introduced before re-checking.
- If the user selects 0, a delay is added before prompting for device selection again.
- The method now asynchronously waits for available devices before prompting the user for a selection.

Asana: https://app.asana.com/0/1209147429100805/1209210623692344/f