### PR TITLE
Fixed mavlink command not receiving any packets

### DIFF
--- a/src/Asv.Mavlink.Shell/Tests/MavlinkCommand.cs
+++ b/src/Asv.Mavlink.Shell/Tests/MavlinkCommand.cs
@@ -36,6 +36,7 @@ namespace Asv.Mavlink.Shell
                 builder.RegisterMavlinkV2Protocol();
             }).CreateRouter("ROUTER");
 
+            conn.AddPort(_connectionString);
             conn.OnRxMessage.FilterByType<MavlinkMessage>().Subscribe(OnPacket);
             
             while (!_cancel.IsCancellationRequested)


### PR DESCRIPTION
Connection string was not being passed to the protocol router and it resulted in it not listening to any packets. 
Mission Planner's SITL was used to try to establish a connection with asv-mavlink for this purpose.

With the correction:
![Captura de tela 2025-02-02 201200](https://github.com/user-attachments/assets/1398d6ea-d556-4b75-aa04-544459bec9c3)

Without the correction:
![Captura de tela 2025-02-02 201120](https://github.com/user-attachments/assets/e761725e-1d6a-4cdc-aefc-bb91dcc94adb)
