### PR TITLE
fix: incorrect comparison prevented mavlink v2 signature from being d…

### DIFF
--- a/src/Asv.Mavlink/Protocol/V2/MavlinkV2Parser.cs
+++ b/src/Asv.Mavlink/Protocol/V2/MavlinkV2Parser.cs
@@ -78,7 +78,7 @@ public class MavlinkV2Parser:ProtocolParser<MavlinkMessage,int>
                         _decodeStep = DecodeStep.Sync;
                         return false;
                     }
-                    if (_bufferIndex <= _bufferStopIndex + MavlinkV2Protocol.SignatureByteSize)
+                    if (_bufferIndex >= _bufferStopIndex + MavlinkV2Protocol.SignatureByteSize)
                     {
                         TryDecodePacket(_bufferIndex);
                         _decodeStep = DecodeStep.Sync;


### PR DESCRIPTION
TryDecodePacket was being called before the signature bytes were read into the buffer due to the incorrect comparison sign